### PR TITLE
Add EFCore posts samples

### DIFF
--- a/sample/FastEndpoints/Source/EFModel/BlogContext.cs
+++ b/sample/FastEndpoints/Source/EFModel/BlogContext.cs
@@ -1,0 +1,47 @@
+﻿namespace Panner.AspNetCore.Samples.FastEndpointsNet9.EFModel
+{
+    using Microsoft.EntityFrameworkCore;
+    using System;
+
+    public class BlogContext : DbContext
+    {
+        public DbSet<Post> Posts { get; set; }
+
+        public BlogContext() : base()
+        {
+        }
+
+        public BlogContext(DbContextOptions options) : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Post>()
+                .HasData(new Post()
+                {
+                    Id = 1,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = true
+                }, new Post()
+                {
+                    Id = 2,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = false
+                }, new Post()
+                {
+                    Id = 3,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = true
+                });
+        }
+    }
+}

--- a/sample/FastEndpoints/Source/EFModel/Post.cs
+++ b/sample/FastEndpoints/Source/EFModel/Post.cs
@@ -1,0 +1,15 @@
+﻿namespace Panner.AspNetCore.Samples.FastEndpointsNet9.EFModel
+{
+    using System;
+
+    public class Post
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public bool IsVisible { get; set; }
+        public int AmtLikes { get; set; }
+        public int AmtComments { get; set; }
+        public DateTime CreatedOn { get; set; }
+    }
+}

--- a/sample/FastEndpoints/Source/FastEndpointsNet9.csproj
+++ b/sample/FastEndpoints/Source/FastEndpointsNet9.csproj
@@ -11,11 +11,17 @@
         <RootNamespace>Panner.AspNetCore.Samples.FastEndpointsNet9</RootNamespace>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="FastEndpoints" Version="6.0.0"/>
-        <PackageReference Include="FastEndpoints.Generator" Version="6.0.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"/>
-        <PackageReference Include="FastEndpoints.Security" Version="6.0.0"/>
-        <PackageReference Include="FastEndpoints.Swagger" Version="6.0.0"/>
-    </ItemGroup>
+  <ItemGroup>
+      <PackageReference Include="FastEndpoints" Version="6.0.0" />
+      <PackageReference Include="FastEndpoints.Generator" Version="6.0.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+      <PackageReference Include="FastEndpoints.Security" Version="6.0.0" />
+      <PackageReference Include="FastEndpoints.Swagger" Version="6.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+      <ProjectReference Include="..\..\..\src\Panner.AspNetCore.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/sample/FastEndpoints/Source/Features/Posts/Endpoint.cs
+++ b/sample/FastEndpoints/Source/Features/Posts/Endpoint.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using Panner.AspNetCore.Samples.FastEndpointsNet9.EFModel;
+using Panner.AspNetCore.Samples.FastEndpointsNet9.PannerExtensions;
+
+namespace Posts;
+
+sealed class Endpoint : Endpoint<Request, IEnumerable<Views.Post>>
+{
+    private readonly BlogContext _context;
+
+    public Endpoint(BlogContext context)
+    {
+        _context = context;
+    }
+
+    public override void Configure()
+    {
+        Get("/posts");
+        AllowAnonymous();
+    }
+
+    public override async Task HandleAsync(Request r, CancellationToken c)
+    {
+        _context.Database.EnsureCreated();
+        var result = await _context.Posts
+            .Apply(r.Filters ?? Array.Empty<IFilterParticle<Post>>())
+            .Apply(r.Sorts ?? Array.Empty<ISortParticle<Post>>())
+            .Select(x => new Views.Post
+            {
+                Id = x.Id,
+                Title = x.Title,
+                Content = x.Content,
+                Creation = x.CreatedOn
+            })
+            .ToArrayAsync(c);
+
+        await SendAsync(result, cancellation: c);
+    }
+}

--- a/sample/FastEndpoints/Source/Features/Posts/Request.cs
+++ b/sample/FastEndpoints/Source/Features/Posts/Request.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+using Panner;
+using Panner.AspNetCore.Samples.FastEndpointsNet9.EFModel;
+
+namespace Posts;
+
+sealed class Request
+{
+    [FromQuery]
+    public IReadOnlyCollection<ISortParticle<Post>>? Sorts { get; set; }
+
+    [FromQuery]
+    public IReadOnlyCollection<IFilterParticle<Post>>? Filters { get; set; }
+}

--- a/sample/FastEndpoints/Source/PannerExtensions/PEntityBuilder.Post.IsSortableByPopularity.cs
+++ b/sample/FastEndpoints/Source/PannerExtensions/PEntityBuilder.Post.IsSortableByPopularity.cs
@@ -1,0 +1,15 @@
+﻿namespace Panner.AspNetCore.Samples.FastEndpointsNet9.PannerExtensions
+{
+    using global::Panner.AspNetCore.Samples.FastEndpointsNet9.EFModel;
+    using global::Panner.Builders;
+
+    public static partial class PEntityBuilderExtensions
+    {
+        /// <summary>Marks the entity as sortable by popularity.</summary>
+        public static PEntityBuilder<Post> IsSortableByPopularity(this PEntityBuilder<Post> builder)
+        {
+            builder.GetOrCreateGenerator<ISortParticle<Post>, SortPostsByPopularityParticleGenerator>();
+            return builder;
+        }
+    }
+}

--- a/sample/FastEndpoints/Source/PannerExtensions/SortPostByPopularityParticle.cs
+++ b/sample/FastEndpoints/Source/PannerExtensions/SortPostByPopularityParticle.cs
@@ -1,0 +1,27 @@
+﻿namespace Panner.AspNetCore.Samples.FastEndpointsNet9.PannerExtensions
+{
+    using global::Panner.AspNetCore.Samples.FastEndpointsNet9.EFModel;
+    using System.Linq;
+
+    public class SortPostByPopularityParticle : ISortParticle<Post>
+    {
+        readonly bool Descending;
+
+        public SortPostByPopularityParticle(bool descending)
+        {
+            this.Descending = descending;
+        }
+
+        public IOrderedQueryable<Post> ApplyTo(IOrderedQueryable<Post> source)
+        {
+            if (this.Descending)
+                return source
+                    .ThenByDescending(x => x.AmtLikes)
+                    .ThenByDescending(x => x.AmtComments);
+            else
+                return source
+                    .ThenBy(x => x.AmtLikes)
+                    .ThenBy(x => x.AmtComments);
+        }
+    }
+}

--- a/sample/FastEndpoints/Source/PannerExtensions/SortPostsByPopularityParticleGenerator.cs
+++ b/sample/FastEndpoints/Source/PannerExtensions/SortPostsByPopularityParticleGenerator.cs
@@ -1,0 +1,22 @@
+﻿using Panner.AspNetCore.Samples.FastEndpointsNet9.EFModel;
+
+namespace Panner.AspNetCore.Samples.FastEndpointsNet9.PannerExtensions
+{
+    public class SortPostsByPopularityParticleGenerator : ISortParticleGenerator<Post>
+    {
+        public bool TryGenerate(IPContext context, string input, out ISortParticle<Post> particle)
+        {
+            var descending = input.StartsWith('-');
+            var remaining = descending ? input.Substring(1) : input;
+
+            if (!remaining.Trim().Equals("Popularity", System.StringComparison.OrdinalIgnoreCase))
+            {
+                particle = null;
+                return false;
+            }
+
+            particle = new SortPostByPopularityParticle(descending);
+            return true;
+        }
+    }
+}

--- a/sample/FastEndpoints/Source/Program.cs
+++ b/sample/FastEndpoints/Source/Program.cs
@@ -1,9 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Panner.AspNetCore.Samples.FastEndpointsNet9.EFModel;
+using Panner.AspNetCore.Samples.FastEndpointsNet9.PannerExtensions;
+using Panner.Builders;
+
 var bld = WebApplication.CreateBuilder(args);
+
 bld.Services
     .AddAuthenticationJwtBearer(s => s.SigningKey = bld.Configuration["Auth:JwtKey"])
     .AddAuthorization()
     .AddFastEndpoints(o => o.SourceGeneratorDiscoveredTypes = DiscoveredTypes.All)
     .SwaggerDocument();
+
+bld.Services.UsePanner(c =>
+{
+    c.Entity<Post>()
+        .IsSortableByPopularity()
+        .Property(x => x.Id, o => o
+            .IsSortableAs(nameof(Views.Post.Id))
+            .IsFilterableAs(nameof(Views.Post.Id))
+        )
+        .Property(x => x.Title, o => o
+            .IsSortableAs(nameof(Views.Post.Title))
+        )
+        .Property(x => x.CreatedOn, o => o
+            .IsSortableAs(nameof(Views.Post.Creation))
+            .IsFilterableAs(nameof(Views.Post.Creation))
+        );
+});
+
+bld.Services.AddDbContext<BlogContext>(o => o.UseInMemoryDatabase("BlogDb"));
 
 var app = bld.Build();
 app.UseAuthentication()

--- a/sample/FastEndpoints/Source/Views/Post.cs
+++ b/sample/FastEndpoints/Source/Views/Post.cs
@@ -1,0 +1,12 @@
+﻿namespace Panner.AspNetCore.Samples.FastEndpointsNet9.Views
+{
+    using System;
+
+    public class Post
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public DateTime Creation { get; set; }
+    }
+}

--- a/samples/WebAPINet8MinimalFluent/EFModel/BlogContext.cs
+++ b/samples/WebAPINet8MinimalFluent/EFModel/BlogContext.cs
@@ -1,0 +1,47 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet8MinimalFluent.EFModel
+{
+    using Microsoft.EntityFrameworkCore;
+    using System;
+
+    public class BlogContext : DbContext
+    {
+        public DbSet<Post> Posts { get; set; }
+
+        public BlogContext() : base()
+        {
+        }
+
+        public BlogContext(DbContextOptions options) : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Post>()
+                .HasData(new Post()
+                {
+                    Id = 1,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = true
+                }, new Post()
+                {
+                    Id = 2,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = false
+                }, new Post()
+                {
+                    Id = 3,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = true
+                });
+        }
+    }
+}

--- a/samples/WebAPINet8MinimalFluent/EFModel/Post.cs
+++ b/samples/WebAPINet8MinimalFluent/EFModel/Post.cs
@@ -1,0 +1,15 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet8MinimalFluent.EFModel
+{
+    using System;
+
+    public class Post
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public bool IsVisible { get; set; }
+        public int AmtLikes { get; set; }
+        public int AmtComments { get; set; }
+        public DateTime CreatedOn { get; set; }
+    }
+}

--- a/samples/WebAPINet8MinimalFluent/PannerExtensions/PEntityBuilder.Post.IsSortableByPopularity.cs
+++ b/samples/WebAPINet8MinimalFluent/PannerExtensions/PEntityBuilder.Post.IsSortableByPopularity.cs
@@ -1,0 +1,15 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet8MinimalFluent.PannerExtensions
+{
+    using global::Panner.AspNetCore.Samples.WebApiNet8MinimalFluent.EFModel;
+    using global::Panner.Builders;
+
+    public static partial class PEntityBuilderExtensions
+    {
+        /// <summary>Marks the entity as sortable by popularity.</summary>
+        public static PEntityBuilder<Post> IsSortableByPopularity(this PEntityBuilder<Post> builder)
+        {
+            builder.GetOrCreateGenerator<ISortParticle<Post>, SortPostsByPopularityParticleGenerator>();
+            return builder;
+        }
+    }
+}

--- a/samples/WebAPINet8MinimalFluent/PannerExtensions/SortPostByPopularityParticle.cs
+++ b/samples/WebAPINet8MinimalFluent/PannerExtensions/SortPostByPopularityParticle.cs
@@ -1,0 +1,27 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet8MinimalFluent.PannerExtensions
+{
+    using global::Panner.AspNetCore.Samples.WebApiNet8MinimalFluent.EFModel;
+    using System.Linq;
+
+    public class SortPostByPopularityParticle : ISortParticle<Post>
+    {
+        readonly bool Descending;
+
+        public SortPostByPopularityParticle(bool descending)
+        {
+            this.Descending = descending;
+        }
+
+        public IOrderedQueryable<Post> ApplyTo(IOrderedQueryable<Post> source)
+        {
+            if (this.Descending)
+                return source
+                    .ThenByDescending(x => x.AmtLikes)
+                    .ThenByDescending(x => x.AmtComments);
+            else
+                return source
+                    .ThenBy(x => x.AmtLikes)
+                    .ThenBy(x => x.AmtComments);
+        }
+    }
+}

--- a/samples/WebAPINet8MinimalFluent/PannerExtensions/SortPostsByPopularityParticleGenerator.cs
+++ b/samples/WebAPINet8MinimalFluent/PannerExtensions/SortPostsByPopularityParticleGenerator.cs
@@ -1,0 +1,22 @@
+﻿using Panner.AspNetCore.Samples.WebApiNet8MinimalFluent.EFModel;
+
+namespace Panner.AspNetCore.Samples.WebApiNet8MinimalFluent.PannerExtensions
+{
+    public class SortPostsByPopularityParticleGenerator : ISortParticleGenerator<Post>
+    {
+        public bool TryGenerate(IPContext context, string input, out ISortParticle<Post> particle)
+        {
+            var descending = input.StartsWith('-');
+            var remaining = descending ? input.Substring(1) : input;
+
+            if (!remaining.Trim().Equals("Popularity", System.StringComparison.OrdinalIgnoreCase))
+            {
+                particle = null;
+                return false;
+            }
+
+            particle = new SortPostByPopularityParticle(descending);
+            return true;
+        }
+    }
+}

--- a/samples/WebAPINet8MinimalFluent/Program.cs
+++ b/samples/WebAPINet8MinimalFluent/Program.cs
@@ -1,13 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Panner.AspNetCore.Samples.WebApiNet8MinimalFluent.EFModel;
+using Panner.AspNetCore.Samples.WebApiNet8MinimalFluent.PannerExtensions;
+using Panner.Builders;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.UsePanner(c =>
+{
+    c.Entity<Post>()
+        .IsSortableByPopularity()
+        .Property(x => x.Id, o => o
+            .IsSortableAs(nameof(Views.Post.Id))
+            .IsFilterableAs(nameof(Views.Post.Id))
+        )
+        .Property(x => x.Title, o => o
+            .IsSortableAs(nameof(Views.Post.Title))
+        )
+        .Property(x => x.CreatedOn, o => o
+            .IsSortableAs(nameof(Views.Post.Creation))
+            .IsFilterableAs(nameof(Views.Post.Creation))
+        );
+});
+
+builder.Services.AddDbContext<BlogContext>(options =>
+{
+    options.UseInMemoryDatabase("BlogDb");
+});
+
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
@@ -16,29 +41,21 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-var summaries = new[]
+app.MapGet("/posts", async ([FromServices] BlogContext blogContext, [FromQuery] IReadOnlyCollection<ISortParticle<Post>> sorts, [FromQuery] IReadOnlyCollection<IFilterParticle<Post>> filters) =>
 {
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
-    {
-        var forecast = Enumerable.Range(1, 5).Select(index =>
-                new WeatherForecast
-                (
-                    DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-                    Random.Shared.Next(-20, 55),
-                    summaries[Random.Shared.Next(summaries.Length)]
-                ))
-            .ToArray();
-        return forecast;
-    })
-    .WithName("GetWeatherForecast")
-    .WithOpenApi();
+    blogContext.Database.EnsureCreated();
+    var result = await blogContext.Posts
+        .Apply(filters)
+        .Apply(sorts)
+        .Select(x => new Views.Post
+        {
+            Id = x.Id,
+            Title = x.Title,
+            Content = x.Content,
+            Creation = x.CreatedOn
+        })
+        .ToArrayAsync();
+    return Results.Ok(result);
+}).WithOpenApi();
 
 app.Run();
-
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}

--- a/samples/WebAPINet8MinimalFluent/Views/Post.cs
+++ b/samples/WebAPINet8MinimalFluent/Views/Post.cs
@@ -1,0 +1,12 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet8MinimalFluent.Views
+{
+    using System;
+
+    public class Post
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public DateTime Creation { get; set; }
+    }
+}

--- a/samples/WebAPINet8MinimalFluent/WebAPINet8MinimalFluent.csproj
+++ b/samples/WebAPINet8MinimalFluent/WebAPINet8MinimalFluent.csproj
@@ -5,13 +5,19 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <AssemblyName>Panner.AspNetCore.Samples.WebApiNet8MinimalFluent</AssemblyName>
-        <RootNamespace>Panner.AspNetCore.Samples.WebApiNet89MinimalFluent</RootNamespace>
+        <RootNamespace>Panner.AspNetCore.Samples.WebApiNet8MinimalFluent</RootNamespace>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.17" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.17" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Panner.AspNetCore.csproj" />
     </ItemGroup>
 
 </Project>

--- a/samples/WebApi8ControllersFluent/Controllers/PostsController.cs
+++ b/samples/WebApi8ControllersFluent/Controllers/PostsController.cs
@@ -1,0 +1,48 @@
+﻿namespace Panner.AspNetCore.Samples.WebApi8ControllersFluent.Controllers
+{
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using Panner.AspNetCore.Samples.WebApi8ControllersFluent.EFModel;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    [ApiController]
+    [Route("[controller]")]
+    public class PostsController : ControllerBase
+    {
+        private readonly ILogger<PostsController> _logger;
+
+        public PostsController(ILogger<PostsController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetAllPosts(
+            [FromServices] BlogContext blogContext,
+            [FromQuery] IReadOnlyCollection<ISortParticle<Post>> sorts,
+            [FromQuery] IReadOnlyCollection<IFilterParticle<Post>> filters
+        )
+        {
+            // Workaround for: https://github.com/aspnet/EntityFrameworkCore/issues/11666
+            // This is only because we're seeding data OnModelCreation for an InMemoryDatabase
+            blogContext.Database.EnsureCreated();
+
+            var result = await blogContext.Posts
+                    .Apply(filters)
+                    .Apply(sorts)
+                    .Select(x => new Views.Post()
+                    {
+                        Id = x.Id,
+                        Title = x.Title,
+                        Content = x.Content,
+                        Creation = x.CreatedOn
+                    })
+                    .ToArrayAsync();
+
+            return Ok(result);
+        }
+    }
+}

--- a/samples/WebApi8ControllersFluent/EFModel/BlogContext.cs
+++ b/samples/WebApi8ControllersFluent/EFModel/BlogContext.cs
@@ -1,0 +1,47 @@
+﻿namespace Panner.AspNetCore.Samples.WebApi8ControllersFluent.EFModel
+{
+    using Microsoft.EntityFrameworkCore;
+    using System;
+
+    public class BlogContext : DbContext
+    {
+        public DbSet<Post> Posts { get; set; }
+
+        public BlogContext() : base()
+        {
+        }
+
+        public BlogContext(DbContextOptions options) : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Post>()
+                .HasData(new Post()
+                {
+                    Id = 1,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = true
+                }, new Post()
+                {
+                    Id = 2,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = false
+                }, new Post()
+                {
+                    Id = 3,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = true
+                });
+        }
+    }
+}

--- a/samples/WebApi8ControllersFluent/EFModel/Post.cs
+++ b/samples/WebApi8ControllersFluent/EFModel/Post.cs
@@ -1,0 +1,15 @@
+﻿namespace Panner.AspNetCore.Samples.WebApi8ControllersFluent.EFModel
+{
+    using System;
+
+    public class Post
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public bool IsVisible { get; set; }
+        public int AmtLikes { get; set; }
+        public int AmtComments { get; set; }
+        public DateTime CreatedOn { get; set; }
+    }
+}

--- a/samples/WebApi8ControllersFluent/PannerExtensions/PEntityBuilder.Post.IsSortableByPopularity.cs
+++ b/samples/WebApi8ControllersFluent/PannerExtensions/PEntityBuilder.Post.IsSortableByPopularity.cs
@@ -1,0 +1,15 @@
+﻿namespace Panner.AspNetCore.Samples.WebApi8ControllersFluent.PannerExtensions
+{
+    using global::Panner.AspNetCore.Samples.WebApi8ControllersFluent.EFModel;
+    using global::Panner.Builders;
+
+    public static partial class PEntityBuilderExtensions
+    {
+        /// <summary>Marks the entity as sortable by popularity.</summary>
+        public static PEntityBuilder<Post> IsSortableByPopularity(this PEntityBuilder<Post> builder)
+        {
+            builder.GetOrCreateGenerator<ISortParticle<Post>, SortPostsByPopularityParticleGenerator>();
+            return builder;
+        }
+    }
+}

--- a/samples/WebApi8ControllersFluent/PannerExtensions/SortPostByPopularityParticle.cs
+++ b/samples/WebApi8ControllersFluent/PannerExtensions/SortPostByPopularityParticle.cs
@@ -1,0 +1,27 @@
+﻿namespace Panner.AspNetCore.Samples.WebApi8ControllersFluent.PannerExtensions
+{
+    using global::Panner.AspNetCore.Samples.WebApi8ControllersFluent.EFModel;
+    using System.Linq;
+
+    public class SortPostByPopularityParticle : ISortParticle<Post>
+    {
+        readonly bool Descending;
+
+        public SortPostByPopularityParticle(bool descending)
+        {
+            this.Descending = descending;
+        }
+
+        public IOrderedQueryable<Post> ApplyTo(IOrderedQueryable<Post> source)
+        {
+            if (this.Descending)
+                return source
+                    .ThenByDescending(x => x.AmtLikes)
+                    .ThenByDescending(x => x.AmtComments);
+            else
+                return source
+                    .ThenBy(x => x.AmtLikes)
+                    .ThenBy(x => x.AmtComments);
+        }
+    }
+}

--- a/samples/WebApi8ControllersFluent/PannerExtensions/SortPostsByPopularityParticleGenerator.cs
+++ b/samples/WebApi8ControllersFluent/PannerExtensions/SortPostsByPopularityParticleGenerator.cs
@@ -1,0 +1,22 @@
+﻿using Panner.AspNetCore.Samples.WebApi8ControllersFluent.EFModel;
+
+namespace Panner.AspNetCore.Samples.WebApi8ControllersFluent.PannerExtensions
+{
+    public class SortPostsByPopularityParticleGenerator : ISortParticleGenerator<Post>
+    {
+        public bool TryGenerate(IPContext context, string input, out ISortParticle<Post> particle)
+        {
+            var descending = input.StartsWith('-');
+            var remaining = descending ? input.Substring(1) : input;
+
+            if (!remaining.Trim().Equals("Popularity", System.StringComparison.OrdinalIgnoreCase))
+            {
+                particle = null;
+                return false;
+            }
+
+            particle = new SortPostByPopularityParticle(descending);
+            return true;
+        }
+    }
+}

--- a/samples/WebApi8ControllersFluent/Program.cs
+++ b/samples/WebApi8ControllersFluent/Program.cs
@@ -1,15 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Panner.AspNetCore.Samples.WebApi8ControllersFluent.EFModel;
+using Panner.AspNetCore.Samples.WebApi8ControllersFluent.PannerExtensions;
+using Panner.Builders;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-
 builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.UsePanner(c =>
+{
+    c.Entity<Post>()
+        .IsSortableByPopularity()
+        .Property(x => x.Id, o => o
+            .IsSortableAs(nameof(Views.Post.Id))
+            .IsFilterableAs(nameof(Views.Post.Id))
+        )
+        .Property(x => x.Title, o => o
+            .IsSortableAs(nameof(Views.Post.Title))
+        )
+        .Property(x => x.CreatedOn, o => o
+            .IsSortableAs(nameof(Views.Post.Creation))
+            .IsFilterableAs(nameof(Views.Post.Creation))
+        );
+});
+
+builder.Services.AddDbContext<BlogContext>(options =>
+{
+    options.UseInMemoryDatabase("BlogDb");
+});
+
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
@@ -17,9 +40,7 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
-
 app.UseAuthorization();
-
 app.MapControllers();
 
 app.Run();

--- a/samples/WebApi8ControllersFluent/Views/Post.cs
+++ b/samples/WebApi8ControllersFluent/Views/Post.cs
@@ -1,0 +1,12 @@
+﻿namespace Panner.AspNetCore.Samples.WebApi8ControllersFluent.Views
+{
+    using System;
+
+    public class Post
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public DateTime Creation { get; set; }
+    }
+}

--- a/samples/WebApi8ControllersFluent/WebApi8ControllersFluent.csproj
+++ b/samples/WebApi8ControllersFluent/WebApi8ControllersFluent.csproj
@@ -7,7 +7,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.17" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.17" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Panner.AspNetCore.csproj" />
     </ItemGroup>
 
 </Project>

--- a/samples/WebApiNet9ControllersFluent/Controllers/PostsController.cs
+++ b/samples/WebApiNet9ControllersFluent/Controllers/PostsController.cs
@@ -1,0 +1,48 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet9ControllersFluent.Controllers
+{
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using Panner.AspNetCore.Samples.WebApiNet9ControllersFluent.EFModel;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    [ApiController]
+    [Route("[controller]")]
+    public class PostsController : ControllerBase
+    {
+        private readonly ILogger<PostsController> _logger;
+
+        public PostsController(ILogger<PostsController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetAllPosts(
+            [FromServices] BlogContext blogContext,
+            [FromQuery] IReadOnlyCollection<ISortParticle<Post>> sorts,
+            [FromQuery] IReadOnlyCollection<IFilterParticle<Post>> filters
+        )
+        {
+            // Workaround for: https://github.com/aspnet/EntityFrameworkCore/issues/11666
+            // This is only because we're seeding data OnModelCreation for an InMemoryDatabase
+            blogContext.Database.EnsureCreated();
+
+            var result = await blogContext.Posts
+                    .Apply(filters)
+                    .Apply(sorts)
+                    .Select(x => new Views.Post()
+                    {
+                        Id = x.Id,
+                        Title = x.Title,
+                        Content = x.Content,
+                        Creation = x.CreatedOn
+                    })
+                    .ToArrayAsync();
+
+            return Ok(result);
+        }
+    }
+}

--- a/samples/WebApiNet9ControllersFluent/EFModel/BlogContext.cs
+++ b/samples/WebApiNet9ControllersFluent/EFModel/BlogContext.cs
@@ -1,0 +1,47 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet9ControllersFluent.EFModel
+{
+    using Microsoft.EntityFrameworkCore;
+    using System;
+
+    public class BlogContext : DbContext
+    {
+        public DbSet<Post> Posts { get; set; }
+
+        public BlogContext() : base()
+        {
+        }
+
+        public BlogContext(DbContextOptions options) : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Post>()
+                .HasData(new Post()
+                {
+                    Id = 1,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = true
+                }, new Post()
+                {
+                    Id = 2,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = false
+                }, new Post()
+                {
+                    Id = 3,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = true
+                });
+        }
+    }
+}

--- a/samples/WebApiNet9ControllersFluent/EFModel/Post.cs
+++ b/samples/WebApiNet9ControllersFluent/EFModel/Post.cs
@@ -1,0 +1,15 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet9ControllersFluent.EFModel
+{
+    using System;
+
+    public class Post
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public bool IsVisible { get; set; }
+        public int AmtLikes { get; set; }
+        public int AmtComments { get; set; }
+        public DateTime CreatedOn { get; set; }
+    }
+}

--- a/samples/WebApiNet9ControllersFluent/PannerExtensions/PEntityBuilder.Post.IsSortableByPopularity.cs
+++ b/samples/WebApiNet9ControllersFluent/PannerExtensions/PEntityBuilder.Post.IsSortableByPopularity.cs
@@ -1,0 +1,15 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet9ControllersFluent.PannerExtensions
+{
+    using global::Panner.AspNetCore.Samples.WebApiNet9ControllersFluent.EFModel;
+    using global::Panner.Builders;
+
+    public static partial class PEntityBuilderExtensions
+    {
+        /// <summary>Marks the entity as sortable by popularity.</summary>
+        public static PEntityBuilder<Post> IsSortableByPopularity(this PEntityBuilder<Post> builder)
+        {
+            builder.GetOrCreateGenerator<ISortParticle<Post>, SortPostsByPopularityParticleGenerator>();
+            return builder;
+        }
+    }
+}

--- a/samples/WebApiNet9ControllersFluent/PannerExtensions/SortPostByPopularityParticle.cs
+++ b/samples/WebApiNet9ControllersFluent/PannerExtensions/SortPostByPopularityParticle.cs
@@ -1,0 +1,27 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet9ControllersFluent.PannerExtensions
+{
+    using global::Panner.AspNetCore.Samples.WebApiNet9ControllersFluent.EFModel;
+    using System.Linq;
+
+    public class SortPostByPopularityParticle : ISortParticle<Post>
+    {
+        readonly bool Descending;
+
+        public SortPostByPopularityParticle(bool descending)
+        {
+            this.Descending = descending;
+        }
+
+        public IOrderedQueryable<Post> ApplyTo(IOrderedQueryable<Post> source)
+        {
+            if (this.Descending)
+                return source
+                    .ThenByDescending(x => x.AmtLikes)
+                    .ThenByDescending(x => x.AmtComments);
+            else
+                return source
+                    .ThenBy(x => x.AmtLikes)
+                    .ThenBy(x => x.AmtComments);
+        }
+    }
+}

--- a/samples/WebApiNet9ControllersFluent/PannerExtensions/SortPostsByPopularityParticleGenerator.cs
+++ b/samples/WebApiNet9ControllersFluent/PannerExtensions/SortPostsByPopularityParticleGenerator.cs
@@ -1,0 +1,22 @@
+﻿using Panner.AspNetCore.Samples.WebApiNet9ControllersFluent.EFModel;
+
+namespace Panner.AspNetCore.Samples.WebApiNet9ControllersFluent.PannerExtensions
+{
+    public class SortPostsByPopularityParticleGenerator : ISortParticleGenerator<Post>
+    {
+        public bool TryGenerate(IPContext context, string input, out ISortParticle<Post> particle)
+        {
+            var descending = input.StartsWith('-');
+            var remaining = descending ? input.Substring(1) : input;
+
+            if (!remaining.Trim().Equals("Popularity", System.StringComparison.OrdinalIgnoreCase))
+            {
+                particle = null;
+                return false;
+            }
+
+            particle = new SortPostByPopularityParticle(descending);
+            return true;
+        }
+    }
+}

--- a/samples/WebApiNet9ControllersFluent/Program.cs
+++ b/samples/WebApiNet9ControllersFluent/Program.cs
@@ -1,21 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Panner.AspNetCore.Samples.WebApiNet9ControllersFluent.EFModel;
+using Panner.AspNetCore.Samples.WebApiNet9ControllersFluent.PannerExtensions;
+using Panner.Builders;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-
 builder.Services.AddControllers();
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+
+builder.Services.UsePanner(c =>
+{
+    c.Entity<Post>()
+        .IsSortableByPopularity()
+        .Property(x => x.Id, o => o
+            .IsSortableAs(nameof(Views.Post.Id))
+            .IsFilterableAs(nameof(Views.Post.Id))
+        )
+        .Property(x => x.Title, o => o
+            .IsSortableAs(nameof(Views.Post.Title))
+        )
+        .Property(x => x.CreatedOn, o => o
+            .IsSortableAs(nameof(Views.Post.Creation))
+            .IsFilterableAs(nameof(Views.Post.Creation))
+        );
+});
+
+builder.Services.AddDbContext<BlogContext>(options =>
+{
+    options.UseInMemoryDatabase("BlogDb");
+});
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
 }
 
 app.UseHttpsRedirection();
-
 app.UseAuthorization();
 
 app.MapControllers();

--- a/samples/WebApiNet9ControllersFluent/Views/Post.cs
+++ b/samples/WebApiNet9ControllersFluent/Views/Post.cs
@@ -1,0 +1,12 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet9ControllersFluent.Views
+{
+    using System;
+
+    public class Post
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public DateTime Creation { get; set; }
+    }
+}

--- a/samples/WebApiNet9ControllersFluent/WebApiNet9ControllersFluent.csproj
+++ b/samples/WebApiNet9ControllersFluent/WebApiNet9ControllersFluent.csproj
@@ -10,7 +10,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0"/>
-    </ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Panner.AspNetCore.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/samples/WebApiNet9MinimalFluent/EFModel/BlogContext.cs
+++ b/samples/WebApiNet9MinimalFluent/EFModel/BlogContext.cs
@@ -1,0 +1,47 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet9MinimalFluent.EFModel
+{
+    using Microsoft.EntityFrameworkCore;
+    using System;
+
+    public class BlogContext : DbContext
+    {
+        public DbSet<Post> Posts { get; set; }
+
+        public BlogContext() : base()
+        {
+        }
+
+        public BlogContext(DbContextOptions options) : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Post>()
+                .HasData(new Post()
+                {
+                    Id = 1,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = true
+                }, new Post()
+                {
+                    Id = 2,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = false
+                }, new Post()
+                {
+                    Id = 3,
+                    Title = Guid.NewGuid().ToString(),
+                    Content = Guid.NewGuid().ToString(),
+                    CreatedOn = DateTime.UtcNow,
+                    IsVisible = true
+                });
+        }
+    }
+}

--- a/samples/WebApiNet9MinimalFluent/EFModel/Post.cs
+++ b/samples/WebApiNet9MinimalFluent/EFModel/Post.cs
@@ -1,0 +1,15 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet9MinimalFluent.EFModel
+{
+    using System;
+
+    public class Post
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public bool IsVisible { get; set; }
+        public int AmtLikes { get; set; }
+        public int AmtComments { get; set; }
+        public DateTime CreatedOn { get; set; }
+    }
+}

--- a/samples/WebApiNet9MinimalFluent/PannerExtensions/PEntityBuilder.Post.IsSortableByPopularity.cs
+++ b/samples/WebApiNet9MinimalFluent/PannerExtensions/PEntityBuilder.Post.IsSortableByPopularity.cs
@@ -1,0 +1,15 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet9MinimalFluent.PannerExtensions
+{
+    using global::Panner.AspNetCore.Samples.WebApiNet9MinimalFluent.EFModel;
+    using global::Panner.Builders;
+
+    public static partial class PEntityBuilderExtensions
+    {
+        /// <summary>Marks the entity as sortable by popularity.</summary>
+        public static PEntityBuilder<Post> IsSortableByPopularity(this PEntityBuilder<Post> builder)
+        {
+            builder.GetOrCreateGenerator<ISortParticle<Post>, SortPostsByPopularityParticleGenerator>();
+            return builder;
+        }
+    }
+}

--- a/samples/WebApiNet9MinimalFluent/PannerExtensions/SortPostByPopularityParticle.cs
+++ b/samples/WebApiNet9MinimalFluent/PannerExtensions/SortPostByPopularityParticle.cs
@@ -1,0 +1,27 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet9MinimalFluent.PannerExtensions
+{
+    using global::Panner.AspNetCore.Samples.WebApiNet9MinimalFluent.EFModel;
+    using System.Linq;
+
+    public class SortPostByPopularityParticle : ISortParticle<Post>
+    {
+        readonly bool Descending;
+
+        public SortPostByPopularityParticle(bool descending)
+        {
+            this.Descending = descending;
+        }
+
+        public IOrderedQueryable<Post> ApplyTo(IOrderedQueryable<Post> source)
+        {
+            if (this.Descending)
+                return source
+                    .ThenByDescending(x => x.AmtLikes)
+                    .ThenByDescending(x => x.AmtComments);
+            else
+                return source
+                    .ThenBy(x => x.AmtLikes)
+                    .ThenBy(x => x.AmtComments);
+        }
+    }
+}

--- a/samples/WebApiNet9MinimalFluent/PannerExtensions/SortPostsByPopularityParticleGenerator.cs
+++ b/samples/WebApiNet9MinimalFluent/PannerExtensions/SortPostsByPopularityParticleGenerator.cs
@@ -1,0 +1,22 @@
+﻿using Panner.AspNetCore.Samples.WebApiNet9MinimalFluent.EFModel;
+
+namespace Panner.AspNetCore.Samples.WebApiNet9MinimalFluent.PannerExtensions
+{
+    public class SortPostsByPopularityParticleGenerator : ISortParticleGenerator<Post>
+    {
+        public bool TryGenerate(IPContext context, string input, out ISortParticle<Post> particle)
+        {
+            var descending = input.StartsWith('-');
+            var remaining = descending ? input.Substring(1) : input;
+
+            if (!remaining.Trim().Equals("Popularity", System.StringComparison.OrdinalIgnoreCase))
+            {
+                particle = null;
+                return false;
+            }
+
+            particle = new SortPostByPopularityParticle(descending);
+            return true;
+        }
+    }
+}

--- a/samples/WebApiNet9MinimalFluent/Program.cs
+++ b/samples/WebApiNet9MinimalFluent/Program.cs
@@ -1,12 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Panner.AspNetCore.Samples.WebApiNet9MinimalFluent.EFModel;
+using Panner.AspNetCore.Samples.WebApiNet9MinimalFluent.PannerExtensions;
+using Panner.Builders;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+
+builder.Services.UsePanner(c =>
+{
+    c.Entity<Post>()
+        .IsSortableByPopularity()
+        .Property(x => x.Id, o => o
+            .IsSortableAs(nameof(Views.Post.Id))
+            .IsFilterableAs(nameof(Views.Post.Id))
+        )
+        .Property(x => x.Title, o => o
+            .IsSortableAs(nameof(Views.Post.Title))
+        )
+        .Property(x => x.CreatedOn, o => o
+            .IsSortableAs(nameof(Views.Post.Creation))
+            .IsFilterableAs(nameof(Views.Post.Creation))
+        );
+});
+
+builder.Services.AddDbContext<BlogContext>(options =>
+{
+    options.UseInMemoryDatabase("BlogDb");
+});
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
@@ -14,28 +39,21 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-var summaries = new[]
+app.MapGet("/posts", async ([FromServices] BlogContext blogContext, [FromQuery] IReadOnlyCollection<ISortParticle<Post>> sorts, [FromQuery] IReadOnlyCollection<IFilterParticle<Post>> filters) =>
 {
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
-    {
-        var forecast = Enumerable.Range(1, 5).Select(index =>
-                new WeatherForecast
-                (
-                    DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-                    Random.Shared.Next(-20, 55),
-                    summaries[Random.Shared.Next(summaries.Length)]
-                ))
-            .ToArray();
-        return forecast;
-    })
-    .WithName("GetWeatherForecast");
+    blogContext.Database.EnsureCreated();
+    var result = await blogContext.Posts
+        .Apply(filters)
+        .Apply(sorts)
+        .Select(x => new Views.Post
+        {
+            Id = x.Id,
+            Title = x.Title,
+            Content = x.Content,
+            Creation = x.CreatedOn
+        })
+        .ToArrayAsync();
+    return Results.Ok(result);
+});
 
 app.Run();
-
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}

--- a/samples/WebApiNet9MinimalFluent/Views/Post.cs
+++ b/samples/WebApiNet9MinimalFluent/Views/Post.cs
@@ -1,0 +1,12 @@
+﻿namespace Panner.AspNetCore.Samples.WebApiNet9MinimalFluent.Views
+{
+    using System;
+
+    public class Post
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public DateTime Creation { get; set; }
+    }
+}

--- a/samples/WebApiNet9MinimalFluent/WebApiNet9MinimalFluent.csproj
+++ b/samples/WebApiNet9MinimalFluent/WebApiNet9MinimalFluent.csproj
@@ -10,7 +10,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0"/>
-    </ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Panner.AspNetCore.csproj" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- upgrade sample projects to use EF Core and Panner
- add BlogContext/Post model and a posts endpoint

## Testing
- `dotnet test` *(fails: Project Panner.AspNetCore is not compatible with net5.0/netcoreapp3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68676c9118e08332afeb15669663652b