### PR TITLE
Add minimal API model binding

### DIFF
--- a/samples/WebAPINet8MinimalFluent/Program.cs
+++ b/samples/WebAPINet8MinimalFluent/Program.cs
@@ -44,7 +44,10 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-app.MapGet("/posts", async ([FromServices] BlogContext blogContext, [FromQuery] IReadOnlyCollection<ISortParticle<Post>> sorts, [FromQuery] IReadOnlyCollection<IFilterParticle<Post>> filters) =>
+app.MapGet("/posts", async (
+    [FromServices] BlogContext blogContext,
+    SortParticles<Post> sorts,
+    FilterParticles<Post> filters) =>
 {
     blogContext.Database.EnsureCreated();
     var result = await blogContext.Posts

--- a/samples/WebApiNet9MinimalFluent/Program.cs
+++ b/samples/WebApiNet9MinimalFluent/Program.cs
@@ -43,9 +43,9 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 
 app.MapGet("/posts", async (
-    [FromServices] BlogContext blogContext, 
-    [FromQuery] IReadOnlyCollection<ISortParticle<Post>> sorts, 
-    [FromQuery] IReadOnlyCollection<IFilterParticle<Post>> filters
+    [FromServices] BlogContext blogContext,
+    SortParticles<Post> sorts,
+    FilterParticles<Post> filters
 ) =>
 {
     blogContext.Database.EnsureCreated();

--- a/src/Minimal/FilterParticles.cs
+++ b/src/Minimal/FilterParticles.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Panner.AspNetCore
+{
+    public sealed class FilterParticles<TEntity> : IReadOnlyCollection<IFilterParticle<TEntity>>
+        where TEntity : class
+    {
+        private readonly IReadOnlyCollection<IFilterParticle<TEntity>> _particles;
+
+        private FilterParticles(IReadOnlyCollection<IFilterParticle<TEntity>> particles)
+        {
+            _particles = particles;
+        }
+
+        public static ValueTask<FilterParticles<TEntity>> BindAsync(HttpContext context, ParameterInfo parameter)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            if (parameter == null)
+            {
+                throw new ArgumentNullException(nameof(parameter));
+            }
+
+            var queryName = parameter.Name ?? "filters";
+            StringValues value = context.Request.Query[queryName];
+
+            var pContext = context.RequestServices.GetRequiredService<IPContext>();
+
+            if (StringValues.IsNullOrEmpty(value))
+            {
+                return ValueTask.FromResult(new FilterParticles<TEntity>(Array.Empty<IFilterParticle<TEntity>>()));
+            }
+
+            if (!pContext.TryParseCsv(value.ToString(), out IEnumerable<IFilterParticle<TEntity>> particles))
+            {
+                throw new InvalidOperationException("Could not parse provided filters.");
+            }
+
+            return ValueTask.FromResult(new FilterParticles<TEntity>(particles.ToArray()));
+        }
+
+        public int Count => _particles.Count;
+        public IEnumerator<IFilterParticle<TEntity>> GetEnumerator() => _particles.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public IReadOnlyCollection<IFilterParticle<TEntity>> Value => _particles;
+    }
+}

--- a/src/Minimal/SortParticles.cs
+++ b/src/Minimal/SortParticles.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Panner.AspNetCore
+{
+    public sealed class SortParticles<TEntity> : IReadOnlyCollection<ISortParticle<TEntity>>
+        where TEntity : class
+    {
+        private readonly IReadOnlyCollection<ISortParticle<TEntity>> _particles;
+
+        private SortParticles(IReadOnlyCollection<ISortParticle<TEntity>> particles)
+        {
+            _particles = particles;
+        }
+
+        public static ValueTask<SortParticles<TEntity>> BindAsync(HttpContext context, ParameterInfo parameter)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            if (parameter == null)
+            {
+                throw new ArgumentNullException(nameof(parameter));
+            }
+
+            var queryName = parameter.Name ?? "sorts";
+            StringValues value = context.Request.Query[queryName];
+
+            var pContext = context.RequestServices.GetRequiredService<IPContext>();
+
+            if (StringValues.IsNullOrEmpty(value))
+            {
+                return ValueTask.FromResult(new SortParticles<TEntity>(Array.Empty<ISortParticle<TEntity>>()));
+            }
+
+            if (!pContext.TryParseCsv(value.ToString(), out IEnumerable<ISortParticle<TEntity>> particles))
+            {
+                throw new InvalidOperationException("Could not parse provided sorts.");
+            }
+
+            return ValueTask.FromResult(new SortParticles<TEntity>(particles.ToArray()));
+        }
+
+        public int Count => _particles.Count;
+        public IEnumerator<ISortParticle<TEntity>> GetEnumerator() => _particles.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public IReadOnlyCollection<ISortParticle<TEntity>> Value => _particles;
+    }
+}


### PR DESCRIPTION
## Summary
- add `SortParticles` and `FilterParticles` binders for minimal APIs
- update minimal API samples to use these binders

## Testing
- `dotnet test tests/Panner.AspNetCore.Tests/Panner.AspNetCore.Tests.csproj --framework net9.0 -v n`
- `dotnet build src/Panner.AspNetCore.csproj --no-restore -c Debug`

------
https://chatgpt.com/codex/tasks/task_e_686779d659308332b57a6fe66bd25403